### PR TITLE
Determine outputFile extension using mime-types

### DIFF
--- a/lib/image-data-uri.js
+++ b/lib/image-data-uri.js
@@ -21,7 +21,7 @@ let ImageDataURI = (() => {
 			return null;
 		}
 
-		let regExMatches = dataURI.match('data:image/(.*);base64,(.*)');
+		let regExMatches = dataURI.match('data:(image/.*);base64,(.*)');
 		return {
 			imageType: regExMatches[1],
 			dataBase64: regExMatches[2],
@@ -90,7 +90,9 @@ let ImageDataURI = (() => {
 		filePath = filePath || './';
 		return new Promise((resolve, reject) => {
 			let imageDecoded = decode(dataURI);
-			filePath = (!!path.extname(filePath)) ? filePath : filePath + '.' + imageDecoded.imageType;
+			filePath = (!!path.extname(filePath))
+				? filePath
+				: filePath + '.' + mimeTypes.extension(imageDecoded.imageType);
 			fs.outputFile(filePath, imageDecoded.dataBuffer, err => {
 				if (err) {
 					return reject('ImageDataURI :: Error :: ' + JSON.stringify(err, null, 4));

--- a/test/image-data-uri.test.js
+++ b/test/image-data-uri.test.js
@@ -38,4 +38,12 @@ describe("ImageDataURI", () => {
       });
     });
   });
+
+  describe("outputFile", () => {
+    it("writes image/svg+xml data to a file with .svg extension", () => {
+      return ImageDataURI.encodeFromFile("test/test-file.svg")
+        .then(dataURI => ImageDataURI.outputFile(dataURI, "./tmp-output"))
+        .then(outputPath => assert.equal("./tmp-output.svg", outputPath));
+    });
+  });
 });


### PR DESCRIPTION
This fixes `outputFile` regression introduced by #2 which caused media type `image/svg+xml` to have `.svg+xml` extension instead of the proper `.svg`.

Fix implements extension lookup using same mime-types npm module which was used for determining media types in #2.