### PR TITLE
Fixes non-200 status code error handling

### DIFF
--- a/lib/image-data-uri.js
+++ b/lib/image-data-uri.js
@@ -7,6 +7,8 @@ let mimeTypes = require('mime-types');
 
 let ImageDataURI = (options => {
 
+	options = options || {};
+
 	const api = {
 		decode: decode,
 		encode: encode,

--- a/lib/image-data-uri.js
+++ b/lib/image-data-uri.js
@@ -84,7 +84,7 @@ let ImageDataURI = (options => {
 				if (response.statusCode == 200) {
 					return resolve(ImageDataURI.encode(body, response.headers["content-type"]));
 				} else {
-					return reject('ImageDataURI :: Error :: ' + imageURL + ' got HTTP ' + response.statusCode + ' response!');
+					return reject('ImageDataURI :: Error :: GET -> ' + imageURL + ' returned an HTTP ' + response.statusCode + ' status!');
 				}
 			});
 		});

--- a/lib/image-data-uri.js
+++ b/lib/image-data-uri.js
@@ -84,7 +84,7 @@ let ImageDataURI = (options => {
 				if (response.statusCode == 200) {
 					return resolve(ImageDataURI.encode(body, response.headers["content-type"]));
 				} else {
-					return reject('ImageDataURI :: Error :: got HTTP ' + response.statusCode + ' response!');
+					return reject('ImageDataURI :: Error :: ' + imageURL + ' got HTTP ' + response.statusCode + ' response!');
 				}
 			});
 		});

--- a/lib/image-data-uri.js
+++ b/lib/image-data-uri.js
@@ -5,7 +5,7 @@ let request = require('request');
 let path = require('path');
 let mimeTypes = require('mime-types');
 
-let ImageDataURI = (() => {
+let ImageDataURI = (options => {
 
 	const api = {
 		decode: decode,
@@ -73,13 +73,16 @@ let ImageDataURI = (() => {
 			}
 
 			request.get(imageURL, {
-				encoding: null
+				encoding: null,
+				timeout: options.timeout || 6000
 			}, (err, response, body) => {
 				if (err) {
 					return reject('ImageDataURI :: Error :: ' + JSON.stringify(err, null, 4));
 				}
 				if (response.statusCode == 200) {
 					return resolve(ImageDataURI.encode(body, response.headers["content-type"]));
+				} else {
+					return reject('ImageDataURI :: Error :: got HTTP ' + response.statusCode + ' response!');
 				}
 			});
 		});

--- a/lib/image-data-uri.js
+++ b/lib/image-data-uri.js
@@ -5,9 +5,7 @@ let request = require('request');
 let path = require('path');
 let mimeTypes = require('mime-types');
 
-let ImageDataURI = (options => {
-
-	options = options || {};
+let ImageDataURI = (() => {
 
 	const api = {
 		decode: decode,
@@ -67,13 +65,13 @@ let ImageDataURI = (options => {
 
 	}
 
-	function encodeFromURL(imageURL) {
+	function encodeFromURL(imageURL, options) {
 		return new Promise((resolve, reject) => {
 			if (!imageURL) {
 				reject('ImageDataURI :: Error :: Missing some of the required params: imageURL');
 				return null;
 			}
-
+			options = options || {};
 			request.get(imageURL, {
 				encoding: null,
 				timeout: options.timeout || 6000

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "fs-extra": "^0.26.7",
     "magicli": "0.0.8",
     "mime-types": "^2.1.18",
-    "request": "^2.69.0"
+    "request": "^2.88.0"
   },
   "author": {
     "name": "Diego ZoracKy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-data-uri",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Library to easily decode/encode Data URI images",
   "main": "./lib/image-data-uri.js",
   "bin": "./bin/magicli.js",

--- a/test/image-data-uri.test.js
+++ b/test/image-data-uri.test.js
@@ -40,6 +40,21 @@ describe("ImageDataURI", () => {
     });
   });
 
+  describe("encodeFromURL", () => {
+    it("declares correct media type for a google logo", () => {
+      return ImageDataURI.encodeFromURL("https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_120x44dp.png").then(dataURI => {
+        const m = dataURI.match(matchMediaType);
+        assert.equal("image/png", m[1]);
+      });
+    });
+    it("fails on a 404 URL", () => {
+      return ImageDataURI.encodeFromURL("http://150dcace0756dba5a895-b1479f7526781e2361a99185a4979d91.r53.cf1.rackcdn.com/library/assets/825127ec")
+        .catch(err => {
+          assert.ok(typeof err === 'string');
+        });
+    });
+  });
+
   describe("outputFile", () => {
     const outputFilePath = `${__dirname}/tmp-output`;
     const expectedOutputFile = `${__dirname}/tmp-output.svg`;


### PR DESCRIPTION
The request package does not provide an err object when an http 404 is encountered.  This commit provides error handling to the encodeFromURL method supporting 404's and non 200 responses.  Also added a default timeout and options.timeout support.