### PR TITLE
fix(types): add `types` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Library to easily decode/encode Data URI images",
   "main": "./lib/image-data-uri.js",
   "bin": "./bin/magicli.js",
+  "types": "./lib/image-data-uri.d.ts"
   "dependencies": {
     "fs-extra": "^0.26.7",
     "magicli": "0.0.8",


### PR DESCRIPTION
This PR adds the missing `types` property to the package.json file.

closes #15 and closes #10 